### PR TITLE
commandLine: use Gio.Subprocess to execute in a thread

### DIFF
--- a/src/data/commandLine.js
+++ b/src/data/commandLine.js
@@ -23,7 +23,7 @@ var find = (program) => GLib.find_program_in_path(program);
 var execute = (command, stdin = null) => new Promise((resolve, reject) => {
     Log.d(LOGTAG, `Executing: "${command}"`);
 
-    let proc = Gio.Subprocess({
+    let proc = new Gio.Subprocess({
         argv: GLib.shell_parse_argv(command)[1],
         flags: (Gio.SubprocessFlags.STDOUT_PIPE |
                 Gio.SubprocessFlags.STDERR_PIPE)
@@ -32,10 +32,11 @@ var execute = (command, stdin = null) => new Promise((resolve, reject) => {
 
     proc.communicate_utf8_async(stdin, null, (proc, result) => {
         try {
-            let [ok, stdout, stderr] = proc.communicate_utf8_finish(result);
+            let [_, stdout, stderr] = proc.communicate_utf8_finish(result);
 
-            if (proc.get_exit_status() !== 0)
-                throw new Error(stderr);
+            if (proc.get_exit_status() !== 0) {
+                reject(stderr);
+            }
 
             Log.d(LOGTAG, `Output: ${stdout}`);
             resolve(stdout);

--- a/src/data/commandLine.js
+++ b/src/data/commandLine.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 const Log = Me.imports.src.util.log;
@@ -15,20 +16,34 @@ var find = (program) => GLib.find_program_in_path(program);
 
 /**
  * @param {string} command - the command as String (e.g. "ps aux")
+ * @params {string} [input] - optional input for stdin
  * @return {Promise} the command execution result as a String, or fails if an error occur
  */
 /* exported execute */
-var execute = (command) => new Promise((resolve, reject) => {
+var execute = (command, stdin = null) => new Promise((resolve, reject) => {
     Log.d(LOGTAG, `Executing: "${command}"`);
-    const [_, stdout, stderr, status] = GLib.spawn_command_line_sync(command);
-    if (status !== 0) {
-        const error = stderr.toString();
-        Log.e(LOGTAG, error);
-        reject(error);
-    }
-    const output = stdout.toString();
-    Log.d(LOGTAG, `Output: ${output}`);
-    resolve(output);
+
+    let proc = Gio.Subprocess({
+        argv: GLib.shell_parse_argv(command)[1],
+        flags: (Gio.SubprocessFlags.STDOUT_PIPE |
+                Gio.SubprocessFlags.STDERR_PIPE)
+    });
+    proc.init(null);
+
+    proc.communicate_utf8_async(stdin, null, (proc, result) => {
+        try {
+            let [ok, stdout, stderr] = proc.communicate_utf8_finish(result);
+
+            if (proc.get_exit_status() !== 0)
+                throw new Error(stderr);
+
+            Log.d(LOGTAG, `Output: ${stdout}`);
+            resolve(stdout);
+        } catch (e) {
+            Log.e(LOGTAG, e.message);
+            reject(e);
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
Refactor CommandLine.execute() to use Gio.Subprocess, running processes
and awaiting completion in a thread, before resolving the output on
success or stderr on failure.

Just a suggestion from your friendly neighbourhood extension reviewer :)